### PR TITLE
Implement json-log with trace-id for newsletter

### DIFF
--- a/newsletter/Cargo.toml
+++ b/newsletter/Cargo.toml
@@ -42,6 +42,9 @@ diesel-async = { version = "0.6", features = ["postgres", "bb8"] }
 diesel_migrations = { version = "2.2", features = ["postgres"] }
 chrono = "0.4.42"
 tracing-subscriber = { version = "0.3", features = ["fmt", "json", "env-filter"] }
+tracing-opentelemetry = "0.26"
+opentelemetry = { version = "0.26", features = ["trace"] }
+opentelemetry_sdk = { version = "0.26", features = ["trace", "rt-tokio"] }
 anyhow = "1.0.99"
 
 [dependencies.uuid]

--- a/newsletter/src/infrastructure/logging.rs
+++ b/newsletter/src/infrastructure/logging.rs
@@ -1,0 +1,174 @@
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use tracing::{info, error, warn, debug, Level};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use uuid::Uuid;
+
+/// Custom trace context for propagating trace IDs
+#[derive(Debug, Clone)]
+pub struct TraceContext {
+    pub trace_id: String,
+    pub span_id: String,
+    pub operation: String,
+}
+
+impl TraceContext {
+    pub fn new(operation: &str) -> Self {
+        let trace_id = Uuid::new_v4().to_string();
+        let span_id = Uuid::new_v4().to_string();
+        
+        Self {
+            trace_id,
+            span_id,
+            operation: operation.to_string(),
+        }
+    }
+
+    pub fn new_with_trace_id(trace_id: String, operation: &str) -> Self {
+        let span_id = Uuid::new_v4().to_string();
+        
+        Self {
+            trace_id,
+            span_id,
+            operation: operation.to_string(),
+        }
+    }
+}
+
+/// Initialize tracing with JSON formatting and trace context
+pub fn init_tracing() -> anyhow::Result<()> {
+    // Set up tracing subscriber with JSON formatting
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .flatten_event(true)
+                .with_target(true)
+                .with_file(true)
+                .with_line_number(true)
+                .with_current_span(true)
+                .with_span_list(false),
+        )
+        .init();
+
+    Ok(())
+}
+
+/// Log structured JSON with trace context
+pub fn log_with_trace(
+    level: Level,
+    trace_ctx: &TraceContext,
+    message: &str,
+    extra_fields: Option<HashMap<String, Value>>,
+) {
+    let mut fields = json!({
+        "trace_id": trace_ctx.trace_id,
+        "span_id": trace_ctx.span_id,
+        "operation": trace_ctx.operation,
+        "message": message,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "service": "newsletter"
+    });
+
+    if let Some(extra) = extra_fields {
+        if let Value::Object(ref mut map) = fields {
+            for (key, value) in extra {
+                map.insert(key, value);
+            }
+        }
+    }
+
+    match level {
+        Level::ERROR => error!("{}", fields),
+        Level::WARN => warn!("{}", fields),
+        Level::INFO => info!("{}", fields),
+        Level::DEBUG => debug!("{}", fields),
+        Level::TRACE => debug!("{}", fields),
+    }
+}
+
+/// Log CRUD operation start
+pub fn log_crud_start(trace_ctx: &TraceContext, operation: &str, entity: &str, details: Option<HashMap<String, Value>>) {
+    let mut fields = HashMap::new();
+    fields.insert("crud_operation".to_string(), json!(operation));
+    fields.insert("entity".to_string(), json!(entity));
+    fields.insert("status".to_string(), json!("start"));
+    
+    if let Some(details) = details {
+        for (key, value) in details {
+            fields.insert(key, value);
+        }
+    }
+
+    log_with_trace(
+        Level::INFO,
+        trace_ctx,
+        &format!("Starting {} operation on {}", operation, entity),
+        Some(fields),
+    );
+}
+
+/// Log CRUD operation success
+pub fn log_crud_success(trace_ctx: &TraceContext, operation: &str, entity: &str, details: Option<HashMap<String, Value>>) {
+    let mut fields = HashMap::new();
+    fields.insert("crud_operation".to_string(), json!(operation));
+    fields.insert("entity".to_string(), json!(entity));
+    fields.insert("status".to_string(), json!("success"));
+    
+    if let Some(details) = details {
+        for (key, value) in details {
+            fields.insert(key, value);
+        }
+    }
+
+    log_with_trace(
+        Level::INFO,
+        trace_ctx,
+        &format!("Successfully completed {} operation on {}", operation, entity),
+        Some(fields),
+    );
+}
+
+/// Log CRUD operation error
+pub fn log_crud_error(trace_ctx: &TraceContext, operation: &str, entity: &str, error: &str, details: Option<HashMap<String, Value>>) {
+    let mut fields = HashMap::new();
+    fields.insert("crud_operation".to_string(), json!(operation));
+    fields.insert("entity".to_string(), json!(entity));
+    fields.insert("status".to_string(), json!("error"));
+    fields.insert("error".to_string(), json!(error));
+    
+    if let Some(details) = details {
+        for (key, value) in details {
+            fields.insert(key, value);
+        }
+    }
+
+    log_with_trace(
+        Level::ERROR,
+        trace_ctx,
+        &format!("Error in {} operation on {}: {}", operation, entity, error),
+        Some(fields),
+    );
+}
+
+/// Extract trace ID from tonic request headers
+pub fn extract_trace_id_from_request<T>(request: &tonic::Request<T>) -> Option<String> {
+    request
+        .metadata()
+        .get("x-trace-id")
+        .and_then(|value| value.to_str().ok())
+        .map(|s| s.to_string())
+}
+
+/// Create trace context from request or generate new one
+pub fn get_or_create_trace_context<T>(request: &tonic::Request<T>, operation: &str) -> TraceContext {
+    if let Some(trace_id) = extract_trace_id_from_request(request) {
+        TraceContext::new_with_trace_id(trace_id, operation)
+    } else {
+        TraceContext::new(operation)
+    }
+}

--- a/newsletter/src/infrastructure/mod.rs
+++ b/newsletter/src/infrastructure/mod.rs
@@ -1,2 +1,3 @@
 pub mod db;
 pub mod rpc;
+pub mod logging;

--- a/newsletter/src/infrastructure/rpc/newsletter/v1/api.rs
+++ b/newsletter/src/infrastructure/rpc/newsletter/v1/api.rs
@@ -1,7 +1,10 @@
 use async_trait::async_trait;
 use tonic::{Request, Response, Status};
+use serde_json::json;
+use std::collections::HashMap;
 
 use crate::infrastructure::db::PgPool;
+use crate::infrastructure::logging::{self, log_crud_start, log_crud_success, log_crud_error};
 use crate::repository::newsletter::postgres as repo;
 
 use crate::infrastructure::rpc::newsletter::v1::proto::{
@@ -31,12 +34,24 @@ impl MyNewsletterService {
 #[async_trait]
 impl NewsletterService for MyNewsletterService {
     async fn get(&self, req: Request<GetRequest>) -> Result<Response<GetResponse>, Status> {
+        let trace_ctx = logging::get_or_create_trace_context(&req, "newsletter.get");
         let email = req.into_inner().email;
 
+        let mut details = HashMap::new();
+        details.insert("email".to_string(), json!(email));
+        log_crud_start(&trace_ctx, "READ", "newsletter", Some(details.clone()));
+
         // If you add repo::get_by_email later, switch to it for efficiency.
-        let items = repo::list(&self.pool)
-            .await
-            .map_err(|e| Status::internal(format!("db error (list): {e}")))?;
+        let items = match repo::list(&self.pool).await {
+            Ok(items) => {
+                log_crud_success(&trace_ctx, "READ", "newsletter", Some(details.clone()));
+                items
+            }
+            Err(e) => {
+                log_crud_error(&trace_ctx, "READ", "newsletter", &e.to_string(), Some(details));
+                return Err(Status::internal(format!("db error (list): {e}")));
+            }
+        };
 
         let active = items.iter().any(|n| n.email == email && n.active);
 
@@ -44,25 +59,62 @@ impl NewsletterService for MyNewsletterService {
     }
 
     async fn subscribe(&self, req: Request<SubscribeRequest>) -> Result<Response<()>, Status> {
+        let trace_ctx = logging::get_or_create_trace_context(&req, "newsletter.subscribe");
         let email = req.into_inner().email;
-        repo::add(&self.pool, &email)
-            .await
-            .map_err(|e| Status::internal(format!("db error (add): {e}")))?;
-        Ok(Response::new(()))
+
+        let mut details = HashMap::new();
+        details.insert("email".to_string(), json!(email));
+        log_crud_start(&trace_ctx, "CREATE", "newsletter", Some(details.clone()));
+
+        match repo::add(&self.pool, &email).await {
+            Ok(_) => {
+                log_crud_success(&trace_ctx, "CREATE", "newsletter", Some(details));
+                Ok(Response::new(()))
+            }
+            Err(e) => {
+                log_crud_error(&trace_ctx, "CREATE", "newsletter", &e.to_string(), Some(details));
+                Err(Status::internal(format!("db error (add): {e}")))
+            }
+        }
     }
 
     async fn un_subscribe(&self, req: Request<UnSubscribeRequest>) -> Result<Response<()>, Status> {
+        let trace_ctx = logging::get_or_create_trace_context(&req, "newsletter.unsubscribe");
         let email = req.into_inner().email;
-        repo::delete(&self.pool, &email)
-            .await
-            .map_err(|e| Status::internal(format!("db error (delete): {e}")))?;
-        Ok(Response::new(()))
+
+        let mut details = HashMap::new();
+        details.insert("email".to_string(), json!(email));
+        log_crud_start(&trace_ctx, "DELETE", "newsletter", Some(details.clone()));
+
+        match repo::delete(&self.pool, &email).await {
+            Ok(_) => {
+                log_crud_success(&trace_ctx, "DELETE", "newsletter", Some(details));
+                Ok(Response::new(()))
+            }
+            Err(e) => {
+                log_crud_error(&trace_ctx, "DELETE", "newsletter", &e.to_string(), Some(details));
+                Err(Status::internal(format!("db error (delete): {e}")))
+            }
+        }
     }
 
-    async fn list(&self, _req: Request<()>) -> Result<Response<ListResponse>, Status> {
-        let items = repo::list(&self.pool)
-            .await
-            .map_err(|e| Status::internal(format!("db error (list): {e}")))?;
+    async fn list(&self, req: Request<()>) -> Result<Response<ListResponse>, Status> {
+        let trace_ctx = logging::get_or_create_trace_context(&req, "newsletter.list");
+        
+        log_crud_start(&trace_ctx, "READ", "newsletter", None);
+
+        let items = match repo::list(&self.pool).await {
+            Ok(items) => {
+                let mut details = HashMap::new();
+                details.insert("count".to_string(), json!(items.len()));
+                log_crud_success(&trace_ctx, "READ", "newsletter", Some(details));
+                items
+            }
+            Err(e) => {
+                log_crud_error(&trace_ctx, "READ", "newsletter", &e.to_string(), None);
+                return Err(Status::internal(format!("db error (list): {e}")));
+            }
+        };
 
         let newsletters: Vec<Newsletter> = items.into_iter().map(Self::to_proto).collect();
         Ok(Response::new(ListResponse { newsletters }))
@@ -72,33 +124,56 @@ impl NewsletterService for MyNewsletterService {
         &self,
         req: Request<UpdateStatusRequest>,
     ) -> Result<Response<()>, Status> {
+        let trace_ctx = logging::get_or_create_trace_context(&req, "newsletter.update_status");
         let UpdateStatusRequest { emails, active } = req.into_inner();
+
+        let mut details = HashMap::new();
+        details.insert("emails".to_string(), json!(emails));
+        details.insert("active".to_string(), json!(active));
+        details.insert("count".to_string(), json!(emails.len()));
+        
+        let operation = if active { "UPDATE_ACTIVATE" } else { "UPDATE_DEACTIVATE" };
+        log_crud_start(&trace_ctx, operation, "newsletter", Some(details.clone()));
 
         if active {
             // re-subscribe all (ON CONFLICT DO NOTHING in repo::add)
             for email in emails {
-                repo::add(&self.pool, &email)
-                    .await
-                    .map_err(|e| Status::internal(format!("db error (add): {e}")))?;
+                if let Err(e) = repo::add(&self.pool, &email).await {
+                    log_crud_error(&trace_ctx, operation, "newsletter", &e.to_string(), Some(details));
+                    return Err(Status::internal(format!("db error (add): {e}")));
+                }
             }
         } else {
             // unsubscribe all
             for email in emails {
-                repo::delete(&self.pool, &email)
-                    .await
-                    .map_err(|e| Status::internal(format!("db error (delete): {e}")))?;
+                if let Err(e) = repo::delete(&self.pool, &email).await {
+                    log_crud_error(&trace_ctx, operation, "newsletter", &e.to_string(), Some(details));
+                    return Err(Status::internal(format!("db error (delete): {e}")));
+                }
             }
         }
 
+        log_crud_success(&trace_ctx, operation, "newsletter", Some(details));
         Ok(Response::new(()))
     }
 
     async fn delete(&self, req: Request<DeleteRequest>) -> Result<Response<()>, Status> {
-        for email in req.into_inner().emails {
-            repo::delete(&self.pool, &email)
-                .await
-                .map_err(|e| Status::internal(format!("db error (delete): {e}")))?;
+        let trace_ctx = logging::get_or_create_trace_context(&req, "newsletter.delete");
+        let emails = req.into_inner().emails;
+
+        let mut details = HashMap::new();
+        details.insert("emails".to_string(), json!(emails));
+        details.insert("count".to_string(), json!(emails.len()));
+        log_crud_start(&trace_ctx, "DELETE", "newsletter", Some(details.clone()));
+
+        for email in emails {
+            if let Err(e) = repo::delete(&self.pool, &email).await {
+                log_crud_error(&trace_ctx, "DELETE", "newsletter", &e.to_string(), Some(details));
+                return Err(Status::internal(format!("db error (delete): {e}")));
+            }
         }
+
+        log_crud_success(&trace_ctx, "DELETE", "newsletter", Some(details));
         Ok(Response::new(()))
     }
 }

--- a/newsletter/src/repository/newsletter/postgres.rs
+++ b/newsletter/src/repository/newsletter/postgres.rs
@@ -1,12 +1,15 @@
 use crate::domain::newsletter::newsletter::Newsletter;
 use crate::infrastructure::db::db_schema::newsletters;
 use crate::infrastructure::db::PgPool;
+use crate::infrastructure::logging::{TraceContext, log_crud_start, log_crud_success, log_crud_error};
 
 use anyhow::Result;
 use diesel::prelude::*;
 use diesel::SelectableHelper;
 // <- for .as_select()
 use diesel_async::RunQueryDsl;
+use serde_json::json;
+use std::collections::HashMap;
 // <- async query DSL
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -28,12 +31,45 @@ struct NewNewsletter<'a> {
 }
 
 pub async fn list(pool: &PgPool) -> Result<Vec<Newsletter>> {
-    let mut conn = pool.get().await?; // bb8 RunError -> anyhow::Error
-    let rows: Vec<NewsletterRow> = newsletters::table
+    list_with_trace(pool, None).await
+}
+
+pub async fn list_with_trace(pool: &PgPool, trace_ctx: Option<&TraceContext>) -> Result<Vec<Newsletter>> {
+    if let Some(ctx) = trace_ctx {
+        log_crud_start(ctx, "READ", "newsletter_table", None);
+    }
+
+    let mut conn = match pool.get().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            if let Some(ctx) = trace_ctx {
+                log_crud_error(ctx, "READ", "newsletter_table", &e.to_string(), None);
+            }
+            return Err(e.into());
+        }
+    };
+
+    let rows: Vec<NewsletterRow> = match newsletters::table
         .select(NewsletterRow::as_select()) // requires SelectableHelper
         .order(newsletters::id.desc())
         .load(&mut conn)
-        .await?; // Diesel error -> anyhow::Error
+        .await
+    {
+        Ok(rows) => {
+            if let Some(ctx) = trace_ctx {
+                let mut details = HashMap::new();
+                details.insert("rows_count".to_string(), json!(rows.len()));
+                log_crud_success(ctx, "READ", "newsletter_table", Some(details));
+            }
+            rows
+        }
+        Err(e) => {
+            if let Some(ctx) = trace_ctx {
+                log_crud_error(ctx, "READ", "newsletter_table", &e.to_string(), None);
+            }
+            return Err(e.into());
+        }
+    };
 
     Ok(rows
         .into_iter()
@@ -45,8 +81,29 @@ pub async fn list(pool: &PgPool) -> Result<Vec<Newsletter>> {
 }
 
 pub async fn add(pool: &PgPool, email: &str) -> Result<()> {
-    let mut conn = pool.get().await?;
-    diesel::insert_into(newsletters::table)
+    add_with_trace(pool, email, None).await
+}
+
+pub async fn add_with_trace(pool: &PgPool, email: &str, trace_ctx: Option<&TraceContext>) -> Result<()> {
+    if let Some(ctx) = trace_ctx {
+        let mut details = HashMap::new();
+        details.insert("email".to_string(), json!(email));
+        log_crud_start(ctx, "CREATE", "newsletter_table", Some(details));
+    }
+
+    let mut conn = match pool.get().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            if let Some(ctx) = trace_ctx {
+                let mut details = HashMap::new();
+                details.insert("email".to_string(), json!(email));
+                log_crud_error(ctx, "CREATE", "newsletter_table", &e.to_string(), Some(details));
+            }
+            return Err(e.into());
+        }
+    };
+
+    match diesel::insert_into(newsletters::table)
         .values(&NewNewsletter {
             email,
             active: true,
@@ -54,14 +111,70 @@ pub async fn add(pool: &PgPool, email: &str) -> Result<()> {
         .on_conflict(newsletters::email)
         .do_nothing()
         .execute(&mut conn)
-        .await?;
-    Ok(())
+        .await
+    {
+        Ok(_) => {
+            if let Some(ctx) = trace_ctx {
+                let mut details = HashMap::new();
+                details.insert("email".to_string(), json!(email));
+                log_crud_success(ctx, "CREATE", "newsletter_table", Some(details));
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if let Some(ctx) = trace_ctx {
+                let mut details = HashMap::new();
+                details.insert("email".to_string(), json!(email));
+                log_crud_error(ctx, "CREATE", "newsletter_table", &e.to_string(), Some(details));
+            }
+            Err(e.into())
+        }
+    }
 }
 
 pub async fn delete(pool: &PgPool, email: &str) -> Result<()> {
-    let mut conn = pool.get().await?;
-    diesel::delete(newsletters::table.filter(newsletters::email.eq(email)))
+    delete_with_trace(pool, email, None).await
+}
+
+pub async fn delete_with_trace(pool: &PgPool, email: &str, trace_ctx: Option<&TraceContext>) -> Result<()> {
+    if let Some(ctx) = trace_ctx {
+        let mut details = HashMap::new();
+        details.insert("email".to_string(), json!(email));
+        log_crud_start(ctx, "DELETE", "newsletter_table", Some(details));
+    }
+
+    let mut conn = match pool.get().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            if let Some(ctx) = trace_ctx {
+                let mut details = HashMap::new();
+                details.insert("email".to_string(), json!(email));
+                log_crud_error(ctx, "DELETE", "newsletter_table", &e.to_string(), Some(details));
+            }
+            return Err(e.into());
+        }
+    };
+
+    match diesel::delete(newsletters::table.filter(newsletters::email.eq(email)))
         .execute(&mut conn)
-        .await?;
-    Ok(())
+        .await
+    {
+        Ok(rows_affected) => {
+            if let Some(ctx) = trace_ctx {
+                let mut details = HashMap::new();
+                details.insert("email".to_string(), json!(email));
+                details.insert("rows_affected".to_string(), json!(rows_affected));
+                log_crud_success(ctx, "DELETE", "newsletter_table", Some(details));
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if let Some(ctx) = trace_ctx {
+                let mut details = HashMap::new();
+                details.insert("email".to_string(), json!(email));
+                log_crud_error(ctx, "DELETE", "newsletter_table", &e.to_string(), Some(details));
+            }
+            Err(e.into())
+        }
+    }
 }


### PR DESCRIPTION
Add JSON structured logging with trace IDs for all newsletter CRUD operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1380e9b-b56b-46bc-b531-23fb7c89b3eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1380e9b-b56b-46bc-b531-23fb7c89b3eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

